### PR TITLE
Update function name in swatch-renderer-mixin.js

### DIFF
--- a/view/frontend/web/js/swatch-renderer-mixin.js
+++ b/view/frontend/web/js/swatch-renderer-mixin.js
@@ -2,7 +2,7 @@ define(['jquery', 'mage/template', 'productGallery'], function($, template, prod
     return function(originalWidget){
         $.widget(
             'mage.SwatchRenderer', $['mage']['SwatchRenderer'], {
-                processUpdateBaseImage: function (images, context, isInProductView, gallery) {
+                updateBaseImage: function (images, context, isInProductView, gallery) {
                     var justAnImage = images[0],
                         initialImages = this.options.mediaGalleryInitial,
                         imagesToUpdate,


### PR DESCRIPTION
There have been changes to the core swatch-renderer.js file in 2.3.0 and the function we were overriding no longer exists, updating the function to updateBaseImage works as expected.